### PR TITLE
export private functions

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -4,7 +4,7 @@ import { notice, sleep } from './module/general.js'
 import { checkStat } from './module/turnstile.js'
 import { protectPage, protectedBrowser } from 'puppeteer-afp'
 import { puppeteerRealBrowser } from './module/old.js'
-export { puppeteerRealBrowser };
+export { puppeteerRealBrowser, startSession, closeSession, notice, sleep, checkStat };
 
 
 async function handleNewPage({ page, config = {} }) {


### PR DESCRIPTION
To change the `connect` method I need to export some modules.
For example, in this [issue](https://github.com/zfcsoftware/puppeteer-real-browser/issues/32) the author will be able to create his own `connect` function and add adblock plugin