### PR TITLE
Fix turnstile auto click

### DIFF
--- a/src/module/turnstile.js
+++ b/src/module/turnstile.js
@@ -7,7 +7,7 @@ export const checkStat = ({ page }) => {
         }, 4000);
         try {
 
-            const elements = await page.$$('.cf-turnstile-wrapper');
+            const elements = await page.$$('.spacer > div');
 
             if (elements.length <= 0) return resolve(false);
 


### PR DESCRIPTION
Cloudflare changed the class name used on the turnstile , currently i think the div with 'spacer' class is the best pick to target the turnstile div