### PR TITLE
Add 'chrome' to connect function return

### DIFF
--- a/lib/cjs/index.js
+++ b/lib/cjs/index.js
@@ -73,7 +73,8 @@ async function connect({ args = [], headless = false, customConfig = {}, proxy =
 
     return {
         browser,
-        page
+        page,
+        chrome
     }
 }
 

--- a/lib/esm/index.mjs
+++ b/lib/esm/index.mjs
@@ -72,6 +72,7 @@ export async function connect({ args = [], headless = false, customConfig = {}, 
 
     return {
         browser,
-        page
+        page,
+        chrome
     }
 }   

--- a/test/cjs/test.js
+++ b/test/cjs/test.js
@@ -30,25 +30,27 @@ const realBrowserOption = {
 // })
 
 test('DrissionPage Detector', async () => {
-    const { page, browser } = await connect(realBrowserOption)
+    const { page, browser, chrome } = await connect(realBrowserOption)
     await page.goto("https://drissionpage.pages.dev/");
     await page.realClick("#detector")
     let result = await page.evaluate(() => { return document.querySelector('#isBot span').textContent.includes("not") ? true : false })
     await browser.close()
+    await chrome.kill()
     assert.strictEqual(result, true, "DrissionPage Detector test failed!")
 })
 
 test('Brotector, a webdriver detector', async () => {
-    const { page, browser } = await connect(realBrowserOption)
+    const { page, browser, chrome } = await connect(realBrowserOption)
     await page.goto("https://kaliiiiiiiiii.github.io/brotector/");
     await new Promise(r => setTimeout(r, 3000));
     let result = await page.evaluate(() => { return document.querySelector('#table-keys').getAttribute('bgcolor') })
     await browser.close()
+    await chrome.kill()
     assert.strictEqual(result === "darkgreen", true, "Brotector, a webdriver detector test failed!")
 })
 
 test('Cloudflare WAF', async () => {
-    const { page, browser } = await connect(realBrowserOption)
+    const { page, browser, chrome } = await connect(realBrowserOption)
     await page.goto("https://nopecha.com/demo/cloudflare");
     let verify = null
     let startDate = Date.now()
@@ -57,12 +59,13 @@ test('Cloudflare WAF', async () => {
         await new Promise(r => setTimeout(r, 1000));
     }
     await browser.close()
+    await chrome.kill()
     assert.strictEqual(verify === true, true, "Cloudflare WAF test failed!")
 })
 
 
 test('Cloudflare Turnstile', async () => {
-    const { page, browser } = await connect(realBrowserOption)
+    const { page, browser, chrome } = await connect(realBrowserOption)
     await page.goto("https://2captcha.com/demo/cloudflare-turnstile");
     await page.waitForSelector('[data-action="demo_action"]')
     let token = null
@@ -79,6 +82,7 @@ test('Cloudflare Turnstile', async () => {
         await new Promise(r => setTimeout(r, 1000));
     }
     await browser.close()
+    await chrome.kill()
     // if (token !== null) console.log('Cloudflare Turnstile Token: ' + token);
     assert.strictEqual(token !== null, true, "Cloudflare turnstile test failed!")
 })
@@ -86,7 +90,7 @@ test('Cloudflare Turnstile', async () => {
 
 
 test('Recaptcha V3 Score (hard)', async () => {
-    const { page, browser } = await connect(realBrowserOption)
+    const { page, browser, chrome } = await connect(realBrowserOption)
     await page.goto("https://antcpt.com/score_detector/");
     await page.realClick("button")
     await new Promise(r => setTimeout(r, 5000));
@@ -94,17 +98,19 @@ test('Recaptcha V3 Score (hard)', async () => {
         return document.querySelector('big').textContent.replace(/[^0-9.]/g, '')
     })
     await browser.close()
+    await chrome.kill()
     // if (Number(score) >= 0.7) console.log('Recaptcha V3 Score: ' + score);
     assert.strictEqual(Number(score) >= 0.7, true, "Recaptcha V3 Score (hard) should be >=0.7. Score Result: " + score)
 })
 
 test('Fingerprint JS Bot Detector', async () => {
-    const { page, browser } = await connect(realBrowserOption)
+    const { page, browser, chrome } = await connect(realBrowserOption)
     await page.goto("https://fingerprint.com/products/bot-detection/");
     await new Promise(r => setTimeout(r, 5000));
     const detect = await page.evaluate(() => {
         return document.querySelector('.HeroSection-module--botSubTitle--2711e').textContent.includes("not") ? true : false
     })
     await browser.close()
+    await chrome.kill()
     assert.strictEqual(detect, true, "Fingerprint JS Bot Detector test failed!")
 })

--- a/test/esm/test.js
+++ b/test/esm/test.js
@@ -25,32 +25,35 @@ const realBrowserOption = {
 //     realBrowserOption.plugins = [
 //         clickAndWait()
 //     ]
-//     const { page, browser } = await connect(realBrowserOption)
+//     const { page, browser, chrome } = await connect(realBrowserOption)
 //     await page.goto("https://google.com", { waitUntil: "domcontentloaded" })
 //     await page.clickAndWaitForNavigation('body')
 //     await browser.close()
+//     await chrome.kill()
 // })
 
 test('DrissionPage Detector', async () => {
-    const { page, browser } = await connect(realBrowserOption)
+    const { page, browser, chrome } = await connect(realBrowserOption)
     await page.goto("https://drissionpage.pages.dev/");
     await page.realClick("#detector")
     let result = await page.evaluate(() => { return document.querySelector('#isBot span').textContent.includes("not") ? true : false })
     await browser.close()
+    await chrome.kill()
     assert.strictEqual(result, true, "DrissionPage Detector test failed!")
 })
 
 test('Brotector, a webdriver detector', async () => {
-    const { page, browser } = await connect(realBrowserOption)
+    const { page, browser, chrome } = await connect(realBrowserOption)
     await page.goto("https://kaliiiiiiiiii.github.io/brotector/");
     await new Promise(r => setTimeout(r, 3000));
     let result = await page.evaluate(() => { return document.querySelector('#table-keys').getAttribute('bgcolor') })
     await browser.close()
+    await chrome.kill()
     assert.strictEqual(result === "darkgreen", true, "Brotector, a webdriver detector test failed!")
 })
 
 test('Cloudflare WAF', async () => {
-    const { page, browser } = await connect(realBrowserOption)
+    const { page, browser, chrome } = await connect(realBrowserOption)
     await page.goto("https://nopecha.com/demo/cloudflare");
     let verify = null
     let startDate = Date.now()
@@ -59,12 +62,13 @@ test('Cloudflare WAF', async () => {
         await new Promise(r => setTimeout(r, 1000));
     }
     await browser.close()
+    await chrome.kill()
     assert.strictEqual(verify === true, true, "Cloudflare WAF test failed!")
 })
 
 
 test('Cloudflare Turnstile', async () => {
-    const { page, browser } = await connect(realBrowserOption)
+    const { page, browser, chrome } = await connect(realBrowserOption)
     await page.goto("https://2captcha.com/demo/cloudflare-turnstile");
     await page.waitForSelector('[data-action="demo_action"]')
     let token = null
@@ -81,6 +85,7 @@ test('Cloudflare Turnstile', async () => {
         await new Promise(r => setTimeout(r, 1000));
     }
     await browser.close()
+    await chrome.kill()
     // if (token !== null) console.log('Cloudflare Turnstile Token: ' + token);
     assert.strictEqual(token !== null, true, "Cloudflare turnstile test failed!")
 })
@@ -88,7 +93,7 @@ test('Cloudflare Turnstile', async () => {
 
 
 test('Recaptcha V3 Score (hard)', async () => {
-    const { page, browser } = await connect(realBrowserOption)
+    const { page, browser, chrome } = await connect(realBrowserOption)
     await page.goto("https://antcpt.com/score_detector/");
     await page.realClick("button")
     await new Promise(r => setTimeout(r, 5000));
@@ -96,17 +101,19 @@ test('Recaptcha V3 Score (hard)', async () => {
         return document.querySelector('big').textContent.replace(/[^0-9.]/g, '')
     })
     await browser.close()
+    await chrome.kill()
     // if (Number(score) >= 0.7) console.log('Recaptcha V3 Score: ' + score);
     assert.strictEqual(Number(score) >= 0.7, true, "Recaptcha V3 Score (hard) should be >=0.7. Score Result: " + score)
 })
 
 test('Fingerprint JS Bot Detector', async () => {
-    const { page, browser } = await connect(realBrowserOption)
+    const { page, browser, chrome } = await connect(realBrowserOption)
     await page.goto("https://fingerprint.com/products/bot-detection/");
     await new Promise(r => setTimeout(r, 5000));
     const detect = await page.evaluate(() => {
         return document.querySelector('.HeroSection-module--botSubTitle--2711e').textContent.includes("not") ? true : false
     })
     await browser.close()
+    await chrome.kill()
     assert.strictEqual(detect, true, "Fingerprint JS Bot Detector test failed!")
 })


### PR DESCRIPTION
Currently, when you want to close the browser, it doesn't really close because 1 instance remains open. To kill this instance, you need chrome and not the browser (because the 2 are basically launched).

That's why it's important to have Chrome and to kill it after closing the browser